### PR TITLE
Add smart gateway single-page bouncer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Smart Gateway</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      color-scheme: dark;
+    }
+  </style>
+</head>
+<body class="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100 flex items-center justify-center px-6">
+  <main class="w-full max-w-lg">
+    <div class="rounded-3xl border border-slate-800/50 bg-slate-900/70 px-8 py-12 text-center shadow-2xl backdrop-blur">
+      <div id="iconWrapper" class="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-sky-500/10 text-sky-400">
+        <span class="block h-12 w-12 animate-spin rounded-full border-[3px] border-current border-t-transparent"></span>
+      </div>
+      <h1 id="title" class="mt-8 text-3xl font-semibold tracking-tight">Optimizing your connection...</h1>
+      <p id="message" class="mt-4 text-base leading-relaxed text-slate-300" aria-live="polite">
+        Finding the fastest server for you. This will only take a moment.
+      </p>
+      <div id="details" class="mt-6 space-y-3 text-sm text-slate-400">
+        <p class="text-xs uppercase tracking-widest text-slate-500/80">Please keep this tab open while we optimize your connection.</p>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    (() => {
+      const iconWrapper = document.getElementById('iconWrapper');
+      const titleEl = document.getElementById('title');
+      const messageEl = document.getElementById('message');
+      const detailsEl = document.getElementById('details');
+
+      const baseIconClasses = 'mx-auto flex h-20 w-20 items-center justify-center rounded-full';
+      const iconMeta = {
+        spinner: {
+          wrapper: 'bg-sky-500/10 text-sky-400',
+          markup: '<span class="block h-12 w-12 animate-spin rounded-full border-[3px] border-current border-t-transparent"></span>'
+        },
+        browser: {
+          wrapper: 'bg-emerald-500/10 text-emerald-400',
+          markup: '<svg class="h-12 w-12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4 7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v2H4V7z" stroke-linecap="round" stroke-linejoin="round"></path><path d="M4 9h16v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V9z" stroke-linecap="round" stroke-linejoin="round"></path><circle cx="7.5" cy="7" r="0.75" fill="currentColor"></circle><circle cx="10.5" cy="7" r="0.75" fill="currentColor"></circle><circle cx="13.5" cy="7" r="0.75" fill="currentColor"></circle></svg>'
+        },
+        error: {
+          wrapper: 'bg-rose-500/10 text-rose-400',
+          markup: '<svg class="h-12 w-12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 8v4m0 4h.01" stroke-linecap="round" stroke-linejoin="round"></path><path d="M10.29 3.86 2.82 17a1 1 0 0 0 .86 1.5h16.64a1 1 0 0 0 .86-1.5L13.71 3.86a1 1 0 0 0-1.72 0z" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+        }
+      };
+
+      const setView = ({ icon = 'spinner', title, message, details }) => {
+        const meta = iconMeta[icon] || iconMeta.spinner;
+        iconWrapper.className = baseIconClasses + ' ' + meta.wrapper;
+        iconWrapper.innerHTML = meta.markup;
+        titleEl.textContent = title;
+        messageEl.textContent = message;
+        if (details) {
+          detailsEl.innerHTML = details;
+          detailsEl.classList.remove('hidden');
+        } else {
+          detailsEl.innerHTML = '';
+          detailsEl.classList.add('hidden');
+        }
+      };
+
+      const progressHint = '<p class="text-xs uppercase tracking-widest text-slate-500/80">Please keep this tab open while we optimize your connection.</p>';
+
+      const isInAppBrowser = () => {
+        const ua = navigator.userAgent || navigator.vendor || '';
+        const blockedIdentifiers = [/MicroMessenger/i, /AlipayClient/i];
+        return blockedIdentifiers.some((pattern) => pattern.test(ua));
+      };
+
+      // Update this list with every domain or subdomain that hosts the primary service.
+      // The script tests them in order and redirects to the first domain that responds successfully.
+      const domainsToCheck = [
+        'https://www.service-a.com',
+        'https://cdn.service-b.net',
+        'https://eu.service-c.com'
+      ];
+
+      // Global fallback resource that should exist on every domain above.
+      const healthCheckPath = '/health.txt';
+
+      // Optional per-domain overrides for probes that live at a different path.
+      const healthCheckOverrides = {
+        // 'https://cdn.service-b.net': '/status/ping'
+      };
+
+      // Adjust this value to balance accuracy vs. responsiveness (milliseconds).
+      const timeoutMs = 2500;
+
+      const fetchWithTimeout = (resource, options = {}) => {
+        const opts = { ...options };
+        const controllerSupported = typeof AbortController === 'function';
+        const controller = controllerSupported ? new AbortController() : null;
+
+        if (controller) {
+          opts.signal = controller.signal;
+        }
+
+        return new Promise((resolve, reject) => {
+          const timeoutId = setTimeout(() => {
+            if (controller) {
+              controller.abort();
+            }
+            reject(new Error('timeout'));
+          }, timeoutMs);
+
+          fetch(resource, opts)
+            .then((response) => {
+              clearTimeout(timeoutId);
+              resolve(response);
+            })
+            .catch((error) => {
+              clearTimeout(timeoutId);
+              reject(error);
+            });
+        });
+      };
+
+      const normalizeDomain = (domain) => domain.replace(/\/+$/, '');
+      const getTimestamp = () =>
+        typeof performance !== 'undefined' && typeof performance.now === 'function'
+          ? performance.now()
+          : Date.now();
+
+      const checkDomain = async (domain) => {
+        const normalizedDomain = normalizeDomain(domain);
+        const probePath = healthCheckOverrides[normalizedDomain] || healthCheckPath;
+        const probeUrl = normalizedDomain + probePath;
+        const start = getTimestamp();
+
+        try {
+          const response = await fetchWithTimeout(probeUrl, {
+            method: 'GET',
+            cache: 'no-store',
+            mode: 'no-cors'
+          });
+
+          const duration = Math.round(getTimestamp() - start);
+
+          if (!response) {
+            return null;
+          }
+
+          if (response.type === 'opaque' || (response.status >= 200 && response.status < 400)) {
+            console.info(`[Gateway] ${normalizedDomain} responded in ~${duration}ms`);
+            return { domain: normalizedDomain, duration };
+          }
+
+          console.warn(`[Gateway] ${normalizedDomain} responded with status ${response.status}`);
+          return null;
+        } catch (error) {
+          console.warn(`[Gateway] ${normalizedDomain} check failed:`, error);
+          return null;
+        }
+      };
+
+      const runGateway = async () => {
+        if (!domainsToCheck.length) {
+          setView({
+            icon: 'error',
+            title: 'No domains configured',
+            message: 'Please update the bouncer configuration with at least one service endpoint.',
+            details: ''
+          });
+          return;
+        }
+
+        if (isInAppBrowser()) {
+          setView({
+            icon: 'browser',
+            title: 'Please open this page in your browser',
+            message: 'We detected that this link is running inside an in-app browser (such as WeChat or Alipay).',
+            details: '<div class="space-y-2 leading-relaxed"><p>Tap the menu in the corner of this app and choose <strong>“Open in Browser”</strong>.</p><p>Select Safari, Chrome, or your default browser to continue.</p></div>'
+          });
+          return;
+        }
+
+        setView({
+          icon: 'spinner',
+          title: 'Optimizing your connection...',
+          message: 'Finding the fastest server for you. This will only take a moment.',
+          details: progressHint
+        });
+
+        for (const domain of domainsToCheck) {
+          let hostname;
+          try {
+            hostname = new URL(domain).hostname;
+          } catch (_) {
+            hostname = domain;
+          }
+
+          setView({
+            icon: 'spinner',
+            title: 'Optimizing your connection...',
+            message: `Checking ${hostname}...`,
+            details: progressHint
+          });
+
+          const result = await checkDomain(domain);
+          if (result) {
+            setView({
+              icon: 'spinner',
+              title: 'Redirecting…',
+              message: `Connecting through ${hostname} (≈${result.duration} ms).`,
+              details: ''
+            });
+
+            window.location.replace(result.domain);
+            return;
+          }
+        }
+
+        setView({
+          icon: 'error',
+          title: 'Unable to reach our services',
+          message: 'We are sorry, but our services seem to be unavailable from your location at the moment.',
+          details: '<p>Please try again later or contact our support team if the issue persists.</p>'
+        });
+      };
+
+      runGateway();
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Tailwind-powered single-page gateway that performs in-app browser detection
- implement domain probing with configurable health checks and automatic redirection
- show clear loading, blocking, and error states for users across scenarios

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68da0d6a9b2883249bf3416034a45074